### PR TITLE
Import PropTypes from appropriate package

### DIFF
--- a/src/components/Auth.jsx
+++ b/src/components/Auth.jsx
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react'
+import React, {Component} from 'react'
+import PropTypes from 'prop-types'
 
 import config from '../internals/config'
 import { preventBadFacebookHash } from '../internals/utils'

--- a/src/components/Facebook.jsx
+++ b/src/components/Facebook.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import OAuth2 from './OAuth2'
 import env from 'enverse'
 import { isClient } from '../internals/utils'

--- a/src/components/Google.jsx
+++ b/src/components/Google.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import OAuth2 from './OAuth2'
 import env from 'enverse'
 import { isClient } from '../internals/utils'

--- a/src/components/OAuth2.jsx
+++ b/src/components/OAuth2.jsx
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react'
+import React, {Component} from 'react'
+import PropTypes from 'prop-types'
 
 import storage from '../internals/storage'
 import PopupButton from './PopupButton'

--- a/src/components/PopupButton.jsx
+++ b/src/components/PopupButton.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import { parseQueryString } from '../internals/utils'
 
 const propTypes = {

--- a/src/internals/storage/component.jsx
+++ b/src/internals/storage/component.jsx
@@ -8,7 +8,8 @@
 //  - https://github.com/sahat/satellizer/blob/master/src/storage.ts
 // ------------------------------------------------------------------
 
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import Storage from './storage'
 
 export default class StorageComponent extends React.Component {


### PR DESCRIPTION
The patch eliminates PropTypes compatibility warning for React v15.5+